### PR TITLE
[RFC] add macro filter_api

### DIFF
--- a/src/ImagesAPI.jl
+++ b/src/ImagesAPI.jl
@@ -1,5 +1,17 @@
 module ImagesAPI
 
-greet() = print("Hello World!")
+"""
+    AbstractImageAlgorithm
+
+The root of image algorithms type system
+"""
+abstract type AbstractImageAlgorithm end
+
+"""
+    AbstractImageFilter <: AbstractImageAlgorithm
+
+Filters are image algorithms whose input and output are both images
+"""
+abstract type AbstractImageFilter <: AbstractImageAlgorithm end
 
 end # module

--- a/src/ImagesAPI.jl
+++ b/src/ImagesAPI.jl
@@ -14,4 +14,6 @@ Filters are image algorithms whose input and output are both images
 """
 abstract type AbstractImageFilter <: AbstractImageAlgorithm end
 
+include("utils.jl")
+
 end # module

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,86 @@
+"""
+    @filter_api api_name [filter_type=AbstractImageFilter]
+
+This macro it generate two methods:
+
+* `api_name([::Type,] img, f::filter_type, args...)`
+* `api_name!([out,] img, f::filter_type, args...)`
+
+For in-place method `api_name!`, `out` will be changed after calling the method.
+When `out` is not explicitly passed, `img` will be changed after calling the method.
+
+!!! info
+
+    * Any api implementation needs to support a `f(out, in, args...)` method.
+    * This macro is designed to be used in ImagesAPIs, and not downstream packages
+
+## Example:
+
+### 1. register the api in ImagesAPI.jl
+
+```julia
+abstract type AbstractImageNoise <: AbstractImageFilter end
+@filter_api apply_noise AbstractImageNoise
+```
+
+### 2. implement the api in ImageNoise.jl
+```julia
+import Main.ImagesAPI: AbstractImageNoise, AbstractImageFilter, apply_noise, apply_noise!
+
+export
+    apply_noise, apply_noise!,
+    AbstractImageNoise,
+    AdditiveGaussianNoise
+
+struct AdditiveGaussianNoise{T<:AbstractFloat} <: AbstractImageNoise
+    mean::T
+    std::T
+end
+
+function (noise::AdditiveGaussianNoise)(out, in::AbstractArray)
+    @. out = in + noise.std * randn(eltype(out), size(in)) + noise.mean
+end
+```
+
+### 3. user call the API in a consistent way
+```julia
+using ImageNoise
+noise = AdditiveGaussianNoise(0.0, 0.1)
+
+# simple usage
+apply_noise(ones(3,3), noise)
+
+# inplace changing
+img = ones(3,3)
+apply_noise!(img, noise)
+
+# preallocation output
+img = ones(3,3)
+out = zeros(3, 3)
+apply_noise!(out, img, noise)
+```
+"""
+macro filter_api(func_name, filter_type = AbstractImageFilter)
+    inplace_func_name = Symbol(String(func_name) * "!")
+    @eval begin
+        function $(inplace_func_name)(out, img, f::$(filter_type), args...)
+            f(out, img, args...)
+            out
+        end
+
+        function $(inplace_func_name)(img, f::$(filter_type), args...)
+            f(img, img, args...)
+            img
+        end
+
+        function $(func_name)(::Type{T}, img, f::$(filter_type), args...) where T
+            out = Array{T}(undef, size(img)...)
+            $(inplace_func_name)(out, img, f, args...)
+            return out
+        end
+
+        function $(func_name)(img, f::$(filter_type), args...)
+            $(func_name)(eltype(img), img, f, args...)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,20 @@
-using ImagesAPI
+using ImagesAPI: @filter_api, AbstractImageFilter
 using Test
 
 @testset "ImagesAPI.jl" begin
-    # Write your own tests here.
+    @filter_api foo # not working though
+    struct FOO <: AbstractImageFilter end
+    function (::FOO)(out, in)
+        out = in .* 2
+    end
+
+    @test foo(ones(3, 3), FOO()) == ones(3, 3) .* 2
+    in = ones(3, 3)
+    foo!(in, FOO())
+    @test in == ones(3, 3) .* 2
+    in = ones(3, 3)
+    out = zeros(3, 3)
+    foo!(out, in, FOO())
+    @test in == ones(3, 3)
+    @test out == ones(3, 3) .* 2
 end


### PR DESCRIPTION
Here are my thoughts on AbstractImageFilter: https://github.com/JuliaImages/ImagesAPI.jl/issues/2

Probably there're better implementations, but I want to share my ideas here. Also, I'm not sure how broadly this pattern is applicable.

To make it simple and clear, there are two strong assumptions in this macro here:

* input image type and output image type are mutually convertible.
* images are always AbstractArray

and if this pattern looks good, we can implement a more delicate one.

--- 

Use case:

With
```julia
# ImagesAPI.jl
abstract type AbstractImageNoise <: AbstractImageFilter end
@filter_api apply_noise AbstractImageNoise
```

there're two methods `apply_noise` and `apply_noise!` defined in `ImagesAPI`
```julia
apply_noise([::Type,] img, f::filter_type, args...)
apply_noise!([out,] img, f::filter_type, args...)
```

So that in downstream packages such as ImageNoise.jl, implementing a single `f(out, in)` makes everything prepared.

```julia
# ImageNoise.jl
function (noise::AdditiveGaussianNoise)(out, img::AbstractArray)
    @. out = img + noise.std * randn(eltype(out), size(img)) + noise.mean
end
```

users have four ways to call `apply_noise`
```julia
apply_noise(ones(3,3), AdditiveGaussianNoise(0.0, 0.1))

apply_noise(Float32, ones(3,3), AdditiveGaussianNoise(0.0, 0.1))

img = ones(3, 3)
apply_noise!(img, AdditiveGaussianNoise(0.0, 0.1))

in = ones(3,3)
out = zeros(3,3)
apply_noise!(out, in, AdditiveGaussianNoise(0.0, 0.1))
```